### PR TITLE
Add support for GuzzleHttp 7.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "guzzlehttp/guzzle": "^6.0",
+    "guzzlehttp/guzzle": "^6.0|^7.0",
     "illuminate/notifications": "~5.8.0|^6.0|^7.0",
     "laravel/slack-notification-channel": "^2.0"
   },


### PR DESCRIPTION
For use in latest version of Laravel, GuzzleHttp `^7.0` is recommended.