### PR TITLE
Change link key to url

### DIFF
--- a/src/Channels/DiscordWebhookChannel.php
+++ b/src/Channels/DiscordWebhookChannel.php
@@ -91,7 +91,7 @@ class DiscordWebhookChannel
                 'color' => $embed->color,
                 'title' => $embed->title,
                 'description' => $embed->description,
-                'link' => $embed->url,
+                'url' => $embed->url,
                 'thumbnail' => $embed->thumbnail,
                 'image' => $embed->image,
                 'footer' => $embed->footer,


### PR DESCRIPTION
discord embed was not getting the link passed through - changing `link` to `url` worked and now my title is linked