### PR TITLE
Add Laravel 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Laravel Discord Notification Channel 
+# Laravel Discord Notification Channel
 
 ### Introduction
 
@@ -7,14 +7,14 @@ Send Discord messages through webhook with Discord or Slack payload via Laravel 
 ## Features
 - Support slack payload by using `new  (new SlackMessage)` or `$this->toSlack($notifiable)`
 - Support discord webhook payload
-- Easy to use 
+- Easy to use
 
 ## Install
 
 Via Composer
 ``` bash
 composer require awssat/discord-notification-channel
-``` 
+```
 
 ## Usage
 in your notification you should define the `discord` channel in the via method
@@ -36,7 +36,7 @@ you should have a `toDiscord` method
             ->content('Content')
             ->embed(function ($embed) {
                 $embed->title('Discord is cool')->description('Slack nah')
-                    ->field('Laravel', '7.0.0', true)
+                    ->field('Laravel', '8.0.0', true)
                     ->field('PHP', '8.0.0', true);
             });
     }
@@ -101,5 +101,3 @@ class User extends Authenticatable
 }
 
 ```
-
-

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     }
   ],
   "require": {
-    "php": "^7.1.3",
+    "php": "^7.3",
     "guzzlehttp/guzzle": "^6.0|^7.0",
-    "illuminate/notifications": "~5.8.0|^6.0|^7.0",
-    "laravel/slack-notification-channel": "^2.0"
+    "illuminate/notifications": "~5.8.0|^6.0|^7.0|^8.0",
+    "laravel/slack-notification-channel": "^2.2"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     }
   ],
   "require": {
-    "php": "^7.3",
+    "php": "^7.1.3",
     "guzzlehttp/guzzle": "^6.0|^7.0",
     "illuminate/notifications": "~5.8.0|^6.0|^7.0|^8.0",
-    "laravel/slack-notification-channel": "^2.2"
+    "laravel/slack-notification-channel": "^2.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",


### PR DESCRIPTION
This PR adds support for today's release of Laravel 8.

One note about this PR: Laravel 8 bumps the PHP requirement to PHP 7.3 (reflected in the updates). I'm not sure what you want to do about versioning for a change like this, but thought I'd call it out specifically.